### PR TITLE
allow the addition of events without CCA ID

### DIFF
--- a/backend/scheduling/event_handling.py
+++ b/backend/scheduling/event_handling.py
@@ -325,7 +325,7 @@ def createEvent():
         endDateTime = int(data.get('endDateTime'))
         description = str(data.get('description'))
         location = data.get('location')
-        ccaID = int(data.get('ccaID'))
+        ccaID = int(data.get('ccaID')) if data.get('ccaID') else None
         userID = data.get('userID')
         image = data.get('image')
         isPrivate = data.get('isPrivate')
@@ -342,7 +342,8 @@ def createEvent():
             "isPrivate": isPrivate
         }
 
-        receipt = db.Events.insert_one(body)
+        receipt=db.Events.insert_one(body)
+        del body["_id"]
         body["eventID"] = str(receipt.inserted_id)
 
         return {"message": body}, 200


### PR DESCRIPTION
Allow the addition of events without CCA id. This used to be prevented because the int function was called on the ccaID, even when it was null. I simply added a check to see if the ccaID was present before i converted it to int