### PR TITLE
Fix error for AutoComplete CCAs and Modules

### DIFF
--- a/frontend/src/routes/Profile/EditProfile/index.tsx
+++ b/frontend/src/routes/Profile/EditProfile/index.tsx
@@ -78,7 +78,6 @@ export default function EditProfile() {
   let ccaToBeAdded = ''
   let moduleToBeAdded = ''
   const handleChangeAutoComplete = (type: string) => (value: string) => {
-    dispatch(setHasChanged(true))
     switch (type) {
       case 'CCAs':
         ccaToBeAdded = value
@@ -91,6 +90,7 @@ export default function EditProfile() {
   }
 
   const handleAutoCompleteAdd = (type: string, cca: string, module: string) => {
+    dispatch(setHasChanged(true))
     switch (type) {
       case 'CCAs':
         if (cca !== '') {


### PR DESCRIPTION
Fix error by moving dispatch(setHasChanged) from handleChangeAutoComplete to handleAutoCompleteAdd

Functionality slightly modified. Modal asking to confirm discard changes will now only pop out after a CCA/Module is locked in, instead of when a value is being typed. But is the quickest fix because dispatch(setHasChanged) triggers a reload from useEffect.