### PR TITLE
Fix: Lectures with multiple timeslots, only have one shown

### DIFF
--- a/backend/scheduling/event_handling.py
+++ b/backend/scheduling/event_handling.py
@@ -615,6 +615,8 @@ def addNUSModsEvents():
 
         body = {"userID": userID,
                 "mods": indexed_output}
+                
+        db.NUSMods.update_one({"userID": userID}, {"$set": body}, upsert=True)
 
         return json.dumps(db.NUSMods.find_one({"userID": userID}), default=lambda o: str(o)), 200
 


### PR DESCRIPTION
The code assumes that one lecture would only have one timeslot. It no longer has that assumption.