### PR TITLE
Facility API Feature Update (POST add booking and GET booking)

### DIFF
--- a/backend/AuthFunction.py
+++ b/backend/AuthFunction.py
@@ -38,7 +38,7 @@ def authenticate(token, username):
         return False
 
     # recreate session (with createdAt updated to now)
-    #db.Session.remove({'userID': { "$in": data['username']}, 'passwordHash': {"$in": data['passwordHash']}})
+    #db.Session.delete_one({'userID': { "$in": data['username']}, 'passwordHash': {"$in": data['passwordHash']}})
     #db.Session.insert_one({'userID': data['username'], 'passwordHash': data['passwordHash'], 'createdAt': datetime.datetime.now()})
     db.Session.update_many({'userID': data['userID'], 'passwordHash': data['passwordHash']}, {
         '$set': {'createdAt': datetime.datetime.now()}}, upsert=True)

--- a/backend/AuthFunction.py
+++ b/backend/AuthFunction.py
@@ -40,6 +40,6 @@ def authenticate(token, username):
     # recreate session (with createdAt updated to now)
     #db.Session.remove({'userID': { "$in": data['username']}, 'passwordHash': {"$in": data['passwordHash']}})
     #db.Session.insert_one({'userID': data['username'], 'passwordHash': data['passwordHash'], 'createdAt': datetime.datetime.now()})
-    db.Session.update({'userID': data['userID'], 'passwordHash': data['passwordHash']}, {
+    db.Session.update_many({'userID': data['userID'], 'passwordHash': data['passwordHash']}, {
         '$set': {'createdAt': datetime.datetime.now()}}, upsert=True)
     return True

--- a/backend/Authentication/AuthenticationAPI.py
+++ b/backend/Authentication/AuthenticationAPI.py
@@ -77,7 +77,7 @@ def check_for_token(func):
             # recreate session (with createdAt updated to now)
             #db.Session.remove({'userID': { "$in": data['username']}, 'passwordHash': {"$in": data['passwordHash']}})
             #db.Session.insert_one({'userID': data['username'], 'passwordHash': data['passwordHash'], 'createdAt': datetime.datetime.now()})
-            db.Session.update({'userID': data.get('userID'), 'passwordHash': data.get('passwordHash')}, {
+            db.Session.update_many({'userID': data.get('userID'), 'passwordHash': data.get('passwordHash')}, {
                               '$set': {'createdAt': datetime.datetime.now()}}, upsert=True)
 
         return func(currentUser, *args, **kwargs)
@@ -169,7 +169,7 @@ def login():
         return jsonify({'message': 'Invalid credentials'}), 403
     # insert new session into Session table
     #db.Session.createIndex({'createdAt': 1}, { expireAfterSeconds: 120 })
-    db.Session.update({'userID': userID, 'passwordHash': passwordHash}, {'$set': {
+    db.Session.update_many({'userID': userID, 'passwordHash': passwordHash}, {'$set': {
                       'userID': userID, 'passwordHash': passwordHash, 'createdAt': datetime.datetime.now()}}, upsert=True)
     #db.Session.update({'userID': username, 'passwordHash': passwordHash}, {'$set': {'createdAt': datetime.datetime.now()}}, upsert=True)
     # generate JWT (note need to install PyJWT https://stackoverflow.com/questions/33198428/jwt-module-object-has-no-attribute-encode)
@@ -299,7 +299,7 @@ def update_token(token):
         if not db.User.find_one({'userID': associatedUserID}):
             return jsonify({'status': 'failed', 'message': 'Invalid credentials'}), 403
         else:
-            db.User.update(
+            db.User.update_many(
                 {'userID': associatedUserID},
                 {'$set': {'passwordHash': newPasswordHash}
                  }

--- a/backend/Authentication/AuthenticationAPI.py
+++ b/backend/Authentication/AuthenticationAPI.py
@@ -75,7 +75,7 @@ def check_for_token(func):
             return jsonify({'message': 'Token has expired'}), 403
         else:
             # recreate session (with createdAt updated to now)
-            #db.Session.remove({'userID': { "$in": data['username']}, 'passwordHash': {"$in": data['passwordHash']}})
+            #db.Session.delete_one({'userID': { "$in": data['username']}, 'passwordHash': {"$in": data['passwordHash']}})
             #db.Session.insert_one({'userID': data['username'], 'passwordHash': data['passwordHash'], 'createdAt': datetime.datetime.now()})
             db.Session.update_many({'userID': data.get('userID'), 'passwordHash': data.get('passwordHash')}, {
                               '$set': {'createdAt': datetime.datetime.now()}}, upsert=True)
@@ -202,7 +202,7 @@ Delete the session entry
 def logout():
     userID = request.args.get('userID')
     try:
-        db.Session.remove({"userID": userID})
+        db.Session.delete_many({"userID": userID})
     except Exception as e:
         print(e)
         return {"err": "An error has occured", "status": "failed"}, 500

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -90,8 +90,8 @@ def get_one_booking(bookingID):
             {'$project': {'profile': 0, 'cca': 0, 'facility': 0, '_id': 0}}
         ]
 
-        bookingInfo = db.Bookings.aggregate(pipeline)
-        for booking in bookingInfo:
+        data = list(db.Bookings.aggregate(pipeline))
+        for booking in data:
             data = booking
         if len(data) == 0:
             return {"err": "Booking not found", "status": "failed"}, 400

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -180,9 +180,6 @@ def check_bookings(facilityID):
             ]
         }
 
-        if (request.args.get("endTime") <= request.args.get("startTime")):
-            return {"Err" : "Invalid end time."}
-
         if (request.args.get('endTime') != None):
             condition['$and'].append({'startTime': {'$lt': int(
                 request.args.get('endTime'))}})
@@ -190,6 +187,11 @@ def check_bookings(facilityID):
         if (request.args.get('startTime') != None):
             condition['$and'].append({'endTime': {'$gt': int(
                 request.args.get('startTime'))}})
+
+        # BUG 622 Fix: If startTime and endTime are provided, checks if endTime is valid.
+        if (request.args.get("startTime") != None and request.args.get("endTime") != None):
+                    if (request.args.get("endTime") <= request.args.get("startTime")):
+                        return {"Err" : "Invalid end time."}, 403
 
         pipeline = [
             {'$match':

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -269,10 +269,9 @@ def add_booking():
         if formData['facilityID'] == 15 and not db.UserCCA.find_one({'userID': formData['userID'], 'ccaID': 3}):
             return make_response({"err": "You must be in RH Dance to make this booking", "status": "failed"}, 403)
 
-        if not formData.get("forceBook"):
-            formData["forceBook"] = 0
+        if not formData.get("forceBooking"):
+            formData["forceBooking"] = False
 
-        # Handle repeats
         condition = []
 
         for i in range(formData["repeat"]):
@@ -324,7 +323,7 @@ def add_booking():
                 response = {"status": "success", "num_of_successful_bookings": str(len(insertData))}
 
         elif (len(conflict) > 0):
-            if bool(formData["forceBook"]) == False:
+            if formData["forceBooking"] == False:
                 return make_response({"err": "Conflicted booking with previous bookings.", "conflict_bookings": conflict, "status": "failed"}, 409)
             else:
                 insertData = []

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -49,7 +49,6 @@ def get_facility_name(facilityID):
         return {"err": "An error has occured", "status": "failed"}, 500
     return make_response(response)
 
-# TODO: Change the CCA ID to CCA Name
 @ facilities_api.route('/bookings/<int:bookingID>', methods=["GET"])
 @ cross_origin(supports_credentials=True)
 def get_one_booking(bookingID):
@@ -113,11 +112,11 @@ def get_one_booking(bookingID):
 @ cross_origin(supports_credentials=True)
 def user_bookings(userID):
     try:
-        #if (not request.args.get("token")):
-        #    return {"err": "No token", "status": "failed"}, 401
+        if (not request.args.get("token")):
+            return {"err": "No token", "status": "failed"}, 401
 
-        #if (not authenticate(request.args.get("token"), userID)):
-        #    return {"err": "Auth Failure", "status": "failed"}, 401
+        if (not authenticate(request.args.get("token"), userID)):
+            return {"err": "Auth Failure", "status": "failed"}, 401
 
         pipeline = [
             {'$match':
@@ -240,7 +239,6 @@ def check_bookings(facilityID):
         return {"err": "An error has occured", "status": "failed"}, 500
 
     return make_response(response)
-# TODO: End of change here
 
 @ facilities_api.route('/bookings', methods=['POST'])
 @ cross_origin(supports_credentials=True)

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -13,12 +13,14 @@ sys.path.append("../")
 
 facilities_api = Blueprint("facilities", __name__)
 
+# Used to convert CCA ID into CCA Name
+def conversion(ccaID):
+    return str(db.CCA.find_one({"ccaID": ccaID})["ccaName"])
 
 @facilities_api.route('/')
 @cross_origin()
 def root_route():
     return 'What up losers'
-
 
 @facilities_api.route('/facilities', methods=["GET"])
 @cross_origin(supports_credentials=True)
@@ -47,7 +49,7 @@ def get_facility_name(facilityID):
         return {"err": "An error has occured", "status": "failed"}, 500
     return make_response(response)
 
-
+# TODO: Change the CCA ID to CCA Name
 @ facilities_api.route('/bookings/<int:bookingID>', methods=["GET"])
 @ cross_origin(supports_credentials=True)
 def get_one_booking(bookingID):
@@ -94,6 +96,11 @@ def get_one_booking(bookingID):
             data = booking
         if len(data) == 0:
             return {"err": "Booking not found", "status": "failed"}, 400
+
+        if (data["ccaID"] != None):
+            data["ccaName"] = conversion(data["ccaID"])
+            del data["ccaID"]
+
         response = {"status": "success", "data": data}
 
     except Exception as e:
@@ -106,11 +113,11 @@ def get_one_booking(bookingID):
 @ cross_origin(supports_credentials=True)
 def user_bookings(userID):
     try:
-        if (not request.args.get("token")):
-            return {"err": "No token", "status": "failed"}, 401
+        #if (not request.args.get("token")):
+        #    return {"err": "No token", "status": "failed"}, 401
 
-        if (not authenticate(request.args.get("token"), userID)):
-            return {"err": "Auth Failure", "status": "failed"}, 401
+        #if (not authenticate(request.args.get("token"), userID)):
+        #    return {"err": "Auth Failure", "status": "failed"}, 401
 
         pipeline = [
             {'$match':
@@ -156,6 +163,9 @@ def user_bookings(userID):
         data.sort(
             key=lambda x: x.get('startTime'), reverse=False)
 
+        for i in data:
+            del i["ccaID"]
+                
         response = {"status": "success", "data": data}
     except Exception as e:
         print(e)
@@ -221,13 +231,16 @@ def check_bookings(facilityID):
         data.sort(
             key=lambda x: x.get('startTime'), reverse=False)
 
+        for i in data:
+            del i["ccaID"]
+
         response = {"status": "success", "data": data}
     except Exception as e:
         print(e)
         return {"err": "An error has occured", "status": "failed"}, 500
 
     return make_response(response)
-
+# TODO: End of change here
 
 @ facilities_api.route('/bookings', methods=['POST'])
 @ cross_origin(supports_credentials=True)

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -96,9 +96,11 @@ def get_one_booking(bookingID):
         if len(data) == 0:
             return {"err": "Booking not found", "status": "failed"}, 400
 
-        if (data["ccaID"] != None):
-            data["ccaName"] = conversion(data["ccaID"])
-            del data["ccaID"]
+        if data["ccaID"] != None:
+            if data["ccaID"] != 0:
+                data["ccaName"] = conversion(data["ccaID"])
+            
+        del data["ccaID"]
 
         response = {"status": "success", "data": data}
 

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -330,10 +330,7 @@ def add_booking():
 
             db.Bookings.insert_many(insertData)
 
-            if not formData.get("bookUntil"):
-                response = {"status": "success"}
-            else:
-                response = {"status": "success", "num_of_successful_bookings": str(len(insertData))}
+            response = {"status": "success", "num_of_successful_bookings": str(len(insertData))}
 
         elif (len(conflict) > 0):
             if formData["forceBooking"] == False:

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -179,6 +179,10 @@ def check_bookings(facilityID):
                 {'facilityID': int(facilityID)},
             ]
         }
+
+        if (request.args.get("endTime") <= request.args.get("startTime")):
+            return {"Err" : "Invalid end time."}
+
         if (request.args.get('endTime') != None):
             condition['$and'].append({'startTime': {'$lt': int(
                 request.args.get('endTime'))}})

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -330,10 +330,19 @@ def add_booking():
                     editedBooking["bookingID"] += i
 
                 blocked_bookings = {}
+                startTimeArray = []
 
                 for conflict_bookings in conflict:
-                    blocked_bookings[str(dict(conflict_bookings)["startTime"])] = [conflict_bookings]
+                    startTimeArray.append(int(dict(conflict_bookings)["startTime"]))
                 
+                startTimeArray = sorted((set(startTimeArray)), key=int)
+                
+                for timestamp in startTimeArray:
+                    blocked_bookings[str(timestamp)] = []
+                    for conflict_bookings in conflict:
+                        if int(timestamp) == int(dict(conflict_bookings)["startTime"]):
+                            blocked_bookings[str(timestamp)].append(dict(conflict_bookings))
+
                 if len(insertData) != 0:
                     db.Bookings.insert_many(insertData)
                     response = {"message": "Unblocked slots booked", "blocked_bookings": blocked_bookings, "status": "success"}

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -268,12 +268,16 @@ def add_booking():
         if (formData["endTime"] <= formData["startTime"]):
             return {"err": "End time earlier than start time", "status": "failed"}, 400
 
-        if not formData.get("bookUntil"):
+        if not (formData.get("bookUntil") or formData.get("repeat")):
             formData["repeat"] = 1
-        else:
+        elif formData.get("bookUntil") and not formData.get("repeat"):
             formData["repeat"] = int(((int(formData["bookUntil"]) - int(formData["startTime"])) / (7 * 24 * 60 * 60)) + 1)
             if int(formData.get("bookUntil")) < int(formData.get("endTime")):
                 return make_response({"err": "Terminating time of recurring booking earlier than end time of first booking", "status": "failed"}, 400)
+        elif not formData.get("bookUntil") and formData.get("repeat"):
+            formData["repeat"] = int(formData.get("repeat"))
+        else:
+            return make_response({"status": "failed", "message": "Not allowed to have bookUntil and repeat at the same time."}, 400)
         
         if formData['facilityID'] == 15 and not db.UserCCA.find_one({'userID': formData['userID'], 'ccaID': 3}):
             return make_response({"err": "You must be in RH Dance to make this booking", "status": "failed"}, 403)

--- a/backend/FacilityBooking/FacilitiesAPI.py
+++ b/backend/FacilityBooking/FacilitiesAPI.py
@@ -302,6 +302,10 @@ def add_booking():
             [('_id', pymongo.DESCENDING)]).limit(1))
         newBookingID = 1 if len(lastbookingID) == 0 else int(
             lastbookingID[0].get("bookingID")) + 1
+
+        def SpaceOneWeekApart(booking={}):
+            booking["startTime"] += 7 * 24 * 60 * 60
+            booking["endTime"] += 7 * 24 * 60 * 60
         
         if (len(conflict) == 0):
             formData["bookingID"] = newBookingID
@@ -310,8 +314,7 @@ def add_booking():
             for i in range(formData["repeat"]):
                 insertData.append(formData.copy())
                 formData["bookingID"] += 1
-                formData["startTime"] += 7 * 24 * 60 * 60
-                formData["endTime"] += 7 * 24 * 60 * 60
+                SpaceOneWeekApart(formData)
 
             db.Bookings.insert_many(insertData)
 
@@ -327,8 +330,7 @@ def add_booking():
                 insertData = []
                 for i in range(formData["repeat"]):
                     insertData.append(formData.copy())
-                    formData["startTime"] += 7 * 24 * 60 * 60
-                    formData["endTime"] += 7 * 24 * 60 * 60
+                    SpaceOneWeekApart(formData)
             
                 for booking in conflict:
                     for newBooking in insertData:
@@ -359,16 +361,13 @@ def add_booking():
                     db.Bookings.insert_many(insertData)
                     response = {"message": "Unblocked slots booked", "blocked_bookings": blocked_bookings, "num_of_successful_bookings": str(len(insertData)), "status": "success"}
                 else:
-                    return make_response({"message": "All slots have been blocked.", "blocked_bookings": blocked_bookings, "status": "failed"}, 409)
-                
+                    return make_response({"message": "All slots have been blocked.", "blocked_bookings": blocked_bookings, "status": "failed"}, 409)         
 
-        
         # Logging
         formData["action"] = "Add Booking"
         formData["timeStamp"] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
         db.BookingLogs.insert_one(formData)
-
-        
+     
     except Exception as e:
         print(e)
         return {"err": "An error has occured", "status": "failed"}, 500


### PR DESCRIPTION
Update the POST ```/facilities/bookings/``` (```add_bookings()```) such that 2 new JSON arguments are implemented, i.e. ```bookUntil``` and ```forceBooking``` (**updated**), as well as the GET ```bookings``` code segments.

*POST add booking:*
1. ```bookUntil``` (UNIX timestamp in integers): optional argument ~~which replaces ```repeat``` argument for the current version~~ (**Update**: which is an alternative to ```repeat``` [integer] argument); when specified, new bookings are placed recurrently (spaced a week apart) until any point of time within 1 week before the ```bookUntil``` timestamp.

1. ```forceBooking``` (boolean value): required argument; when set as a falsy value (e.g. ```0```), the entire booking request will be rejected if there is at least one conflicting existing booking placed; when set as a truthy value (e.g. ```1```), in case of recurrent bookings, new bookings will be booked if the booking lands on an unblocked slot.

*GET booking:*
For requests that return ```ccaID``` fields, ~~change to returning ```ccaName``` instead~~ (**Update**: add ```ccaName``` alongside).