### PR TITLE
Fix variable and data handling bugs on PUT /social/profiles

### DIFF
--- a/backend/Social/SocialAPI.py
+++ b/backend/Social/SocialAPI.py
@@ -49,8 +49,7 @@ def profiles():
         if (not authenticate(request.args.get("token"), data.get("userID"))):
             return {"err": "Auth Failure", "status": "failed"}, 401
 
-        if "profilePictureURI" in data:
-            data["profilePictureUrl"] = data.pop("profilePictureURI")
+        userID = data.get("userID")
 
         def imgGeneration(imgString):
 
@@ -194,7 +193,6 @@ def profiles():
         else:
             imgKey = "default/profile_pic.png" # profilePictureURI not given, default profile pic will be loaded            
         
-        del data["profilePictureURI"]
         data["imageKey"] = imgKey
 
         result = db.User.update_one({"userID": userID}, {'$set': data}, upsert=True)


### PR DESCRIPTION
Errors that cause the profile picture change "feature" through S3 on ```PUT /social/profiles``` (devel version, not live) not to function properly have been found, and they are as follows:-
1. ```name 'userID' is not defined``` error
1. When a user wants to change the profile picture, the profile picture is not updated to the S3 bucket; instead, only the input ```profilePictureURI``` string is updated to the database.

This PR aims to fix the errors above by changing some lines of the code segment.