### PR TITLE
[FIX] CORS error in middleware

### DIFF
--- a/frontend/src/components/Supper/NotificationBar.tsx
+++ b/frontend/src/components/Supper/NotificationBar.tsx
@@ -94,7 +94,7 @@ export const NotificationBar = () => {
   }, [dispatch])
 
   useEffect(() => {
-    if (supperNotifications.length) {
+    if (supperNotifications !== undefined && supperNotifications.length) {
       setIsVisible(true)
       if (supperNotifications[0].notification === NotificationType.FOOD) {
         setNotifText(

--- a/frontend/src/store/endpoints.ts
+++ b/frontend/src/store/endpoints.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 //https://docs.google.com/spreadsheets/d/1_txnmuoX-rZVrHhZki4wNCBfSZQN3J86lN-PXw1xS4g/edit#gid=328274554
 export enum ENDPOINTS {
   // AUTH
@@ -121,96 +119,63 @@ export enum DOMAINS {
   SUPPER = 'supper',
 }
 
+function proxy(url: string) {
+  return 'https://cors-anywhere-rhapp.herokuapp.com/https:' + url
+}
+
+const DOMAIN_RAW_URL = {
+  FACILITY: '//rhapp-backend.rhdevs.repl.co/facilities',
+  EVENT: '//rhapp-backend.rhdevs.repl.co/scheduling',
+  LAUNDRY: '//rhapp-backend.rhdevs.repl.co/laundry',
+  SOCIAL: '//rhapp-backend.rhdevs.repl.co/social',
+  AUTH: '//rhapp-backend.rhdevs.repl.co/auth',
+  SUPPER: '//rhapp-backend.rhdevs.repl.co/supper',
+}
+
 export const DOMAIN_URL = {
-  FACILITY:
-    process.env.REACT_APP_MODE === 'production'
-      ? '//rhapp-backend.rhdevs.repl.co/facilities'
-      : '//rhappmiddleware.herokuapp.com/rhappfacilities',
-  EVENT:
-    process.env.REACT_APP_MODE === 'production'
-      ? '//rhapp-backend.rhdevs.repl.co/scheduling'
-      : '//rhappmiddleware.herokuapp.com/rhappevents',
-  LAUNDRY:
-    process.env.REACT_APP_MODE === 'production'
-      ? '//rhapp-backend.rhdevs.repl.co/laundry'
-      : '//rhappmiddleware.herokuapp.com/rhapplaundry',
-  SOCIAL:
-    process.env.REACT_APP_MODE === 'production'
-      ? '//rhapp-backend.rhdevs.repl.co/social'
-      : '//rhappmiddleware.herokuapp.com/rhappsocial',
-  AUTH:
-    process.env.REACT_APP_MODE === 'production'
-      ? '//rhapp-backend.rhdevs.repl.co/auth'
-      : '//rhappmiddleware.herokuapp.com/rhappauth',
-  SUPPER:
-    process.env.REACT_APP_MODE === 'production'
-      ? '//rhapp-backend.rhdevs.repl.co/supper'
-      : '//rhappmiddleware.herokuapp.com/rhappsupper',
+  FACILITY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.FACILITY : proxy(DOMAIN_RAW_URL.FACILITY),
+  EVENT: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.EVENT : proxy(DOMAIN_RAW_URL.EVENT),
+  LAUNDRY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.LAUNDRY : proxy(DOMAIN_RAW_URL.LAUNDRY),
+  SOCIAL: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SOCIAL : proxy(DOMAIN_RAW_URL.SOCIAL),
+  AUTH: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.AUTH : proxy(DOMAIN_RAW_URL.AUTH),
+  SUPPER: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_RAW_URL.SUPPER),
 }
 
 async function makeRequest(
   url: string,
   domain: DOMAINS,
   method: 'get' | 'post' | 'delete' | 'put',
-  additionalHeaders: Record<string, unknown> = {},
+  additionalHeaders: HeadersInit | undefined = {},
   requestBody: Record<string, unknown> = {},
 ) {
   let DOMAIN_URL_REQ: string
   switch (domain) {
     case DOMAINS.FACILITY:
-      DOMAIN_URL_REQ =
-        process.env.REACT_APP_MODE === 'production'
-          ? '//rhapp-backend.rhdevs.repl.co/facilities'
-          : '//rhappmiddleware.herokuapp.com/rhappfacilities'
+      DOMAIN_URL_REQ = DOMAIN_URL.FACILITY
       break
     case DOMAINS.EVENT:
-      DOMAIN_URL_REQ =
-        process.env.REACT_APP_MODE === 'production'
-          ? '//rhapp-backend.rhdevs.repl.co/scheduling'
-          : '//rhappmiddleware.herokuapp.com/rhappevents'
+      DOMAIN_URL_REQ = DOMAIN_URL.EVENT
       break
     case DOMAINS.LAUNDRY:
-      DOMAIN_URL_REQ =
-        process.env.REACT_APP_MODE === 'production'
-          ? '//rhapp-backend.rhdevs.repl.co/laundry'
-          : '//rhappmiddleware.herokuapp.com/rhappsocial'
+      DOMAIN_URL_REQ = DOMAIN_URL.LAUNDRY
       break
     case DOMAINS.SOCIAL:
-      DOMAIN_URL_REQ =
-        process.env.REACT_APP_MODE === 'production'
-          ? '//rhapp-backend.rhdevs.repl.co/social'
-          : '//rhappmiddleware.herokuapp.com/rhappsocial'
+      DOMAIN_URL_REQ = DOMAIN_URL.SOCIAL
       break
     case DOMAINS.AUTH:
-      DOMAIN_URL_REQ =
-        process.env.REACT_APP_MODE === 'production'
-          ? '//rhapp-backend.rhdevs.repl.co/auth'
-          : '//rhappmiddleware.herokuapp.com/rhappauth'
+      DOMAIN_URL_REQ = DOMAIN_URL.AUTH
       break
     case DOMAINS.SUPPER:
-      DOMAIN_URL_REQ =
-        process.env.REACT_APP_MODE === 'production'
-          ? '//rhapp-backend.rhdevs.repl.co/supper'
-          : '//rhappmiddleware.herokuapp.com/rhappsupper'
+      DOMAIN_URL_REQ = DOMAIN_URL.SUPPER
       break
   }
-  return axios({
+  return fetch(DOMAIN_URL_REQ + url, {
     method: method,
-    url: DOMAIN_URL_REQ + url,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      ...additionalHeaders,
-    },
-    data: requestBody,
-    // withCredentials: true,
-    validateStatus: (status) => {
-      if (status >= 200 && status < 400) {
-        return true
-      } else {
-        return false
-      }
-    },
-  }).then((response) => response.data)
+    headers: { ...additionalHeaders },
+    body: method === 'get' ? null : JSON.stringify(requestBody),
+  })
+    .then((resp) => resp.json())
+    .catch((err) => console.log(err))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -224,7 +189,7 @@ export function post(
   endpoint: ENDPOINTS,
   domain: DOMAINS,
   requestBody: Record<string, unknown>,
-  additionalHeaders: Record<string, unknown> = {},
+  additionalHeaders: HeadersInit | undefined = {},
   subRoute = '',
 ): ResponsePromise {
   return makeRequest(endpoint + subRoute, domain, 'post', additionalHeaders, requestBody)
@@ -233,7 +198,7 @@ export function post(
 export function del(
   endpoint: ENDPOINTS,
   domain: DOMAINS,
-  additionalHeaders: Record<string, unknown> = {},
+  additionalHeaders: HeadersInit | undefined = {},
   subRoute = '',
 ): ResponsePromise {
   return makeRequest(endpoint + subRoute, domain, 'delete', additionalHeaders)
@@ -243,7 +208,7 @@ export function put(
   endpoint: ENDPOINTS,
   domain: DOMAINS,
   requestBody: Record<string, unknown>,
-  additionalHeaders: Record<string, unknown> = {},
+  additionalHeaders: HeadersInit | undefined = {},
   subRoute = '',
 ): ResponsePromise {
   return makeRequest(endpoint + subRoute, domain, 'put', additionalHeaders, requestBody)

--- a/frontend/src/store/endpoints.ts
+++ b/frontend/src/store/endpoints.ts
@@ -1,3 +1,5 @@
+import axios from 'axios'
+
 //https://docs.google.com/spreadsheets/d/1_txnmuoX-rZVrHhZki4wNCBfSZQN3J86lN-PXw1xS4g/edit#gid=328274554
 export enum ENDPOINTS {
   // AUTH
@@ -183,12 +185,17 @@ async function makeRequest(
       DOMAIN_URL_REQ = DOMAIN_URL.GYM
       break
   }
-  return fetch(DOMAIN_URL_REQ + url, {
+  return axios({
     method: method,
-    headers: { ...additionalHeaders },
-    body: method === 'get' ? null : JSON.stringify(requestBody),
+    url: DOMAIN_URL_REQ + url,
+    headers: {
+      ...additionalHeaders,
+    },
+    data: requestBody,
+    // withCredentials: true,
+    validateStatus: (status) => status >= 200 && status < 400,
   })
-    .then((resp) => resp.json())
+    .then((response) => response.data)
     .catch((err) => console.log(err))
 }
 

--- a/frontend/src/store/endpoints.ts
+++ b/frontend/src/store/endpoints.ts
@@ -132,13 +132,22 @@ const DOMAIN_RAW_URL = {
   SUPPER: '//rhapp-backend.rhdevs.repl.co/supper',
 }
 
+const DOMAIN_DEV_RAW_URL = {
+  FACILITY: '//rhapp-backend-devel.rhdevs.repl.co/facilities',
+  EVENT: '//rhapp-backend-devel.rhdevs.repl.co/scheduling',
+  LAUNDRY: '//rhapp-backend-devel.rhdevs.repl.co/laundry',
+  SOCIAL: '//rhapp-backend-devel.rhdevs.repl.co/social',
+  AUTH: '//rhapp-backend-devel.rhdevs.repl.co/auth',
+  SUPPER: '//rhapp-backend-devel.rhdevs.repl.co/supper',
+}
+
 export const DOMAIN_URL = {
-  FACILITY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.FACILITY : proxy(DOMAIN_RAW_URL.FACILITY),
-  EVENT: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.EVENT : proxy(DOMAIN_RAW_URL.EVENT),
-  LAUNDRY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.LAUNDRY : proxy(DOMAIN_RAW_URL.LAUNDRY),
-  SOCIAL: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SOCIAL : proxy(DOMAIN_RAW_URL.SOCIAL),
-  AUTH: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.AUTH : proxy(DOMAIN_RAW_URL.AUTH),
-  SUPPER: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_RAW_URL.SUPPER),
+  FACILITY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.FACILITY : proxy(DOMAIN_DEV_RAW_URL.FACILITY),
+  EVENT: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.EVENT : proxy(DOMAIN_DEV_RAW_URL.EVENT),
+  LAUNDRY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.LAUNDRY : proxy(DOMAIN_DEV_RAW_URL.LAUNDRY),
+  SOCIAL: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SOCIAL : proxy(DOMAIN_DEV_RAW_URL.SOCIAL),
+  AUTH: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.AUTH : proxy(DOMAIN_DEV_RAW_URL.AUTH),
+  SUPPER: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_DEV_RAW_URL.SUPPER),
 }
 
 async function makeRequest(

--- a/frontend/src/store/endpoints.ts
+++ b/frontend/src/store/endpoints.ts
@@ -10,7 +10,7 @@ export enum ENDPOINTS {
   // USERS
   TELEGRAM_HANDLE = '/users/telegramID', //TODO make backend
   USER = '/user',
-  USER_PROFILE = '/profile/',
+  USER_PROFILE = '/profile',
   USER_PROFILE_PICTURE = '/profile/picture',
   EDIT_PROFILE = '/profiles',
   USER_CCAS = '/user_CCA',
@@ -108,6 +108,14 @@ export enum ENDPOINTS {
   LEAVE_SUPPER_GROUP = '/supperGroup',
   GET_OWNER_EDITS = '/order',
   UPDATE_OWNER_EDITS = '/supperGroup',
+
+  // GYM
+  GET_GYM_HISTORY = '/',
+  GET_GYM_STATUS = '/status',
+  GET_PROFILE_PICTURE = '/keyHolder/profilepic',
+  MOVE_KEY = '/movekey',
+  RETURN_KEY = '/returnkey',
+  TOGGLE_GYM = '/togglegym',
 }
 
 export enum DOMAINS {
@@ -117,6 +125,7 @@ export enum DOMAINS {
   SOCIAL = 'social',
   AUTH = 'auth',
   SUPPER = 'supper',
+  GYM = 'gym',
 }
 
 function proxy(url: string) {
@@ -130,6 +139,7 @@ const DOMAIN_RAW_URL = {
   SOCIAL: '//rhapp-backend.rhdevs.repl.co/social',
   AUTH: '//rhapp-backend.rhdevs.repl.co/auth',
   SUPPER: '//rhapp-backend.rhdevs.repl.co/supper',
+  GYM: '//rhapp-backend.rhdevs.repl.co/gym',
 }
 
 const DOMAIN_DEV_RAW_URL = {
@@ -139,6 +149,7 @@ const DOMAIN_DEV_RAW_URL = {
   SOCIAL: '//rhapp-backend-devel.rhdevs.repl.co/social',
   AUTH: '//rhapp-backend-devel.rhdevs.repl.co/auth',
   SUPPER: '//rhapp-backend-devel.rhdevs.repl.co/supper',
+  GYM: '//rhapp-backend-devel.rhdevs.repl.co/gym',
 }
 
 export const DOMAIN_URL = {
@@ -148,6 +159,7 @@ export const DOMAIN_URL = {
   SOCIAL: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SOCIAL : proxy(DOMAIN_DEV_RAW_URL.SOCIAL),
   AUTH: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.AUTH : proxy(DOMAIN_DEV_RAW_URL.AUTH),
   SUPPER: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_DEV_RAW_URL.SUPPER),
+  GYM: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_DEV_RAW_URL.GYM),
 }
 
 async function makeRequest(
@@ -176,6 +188,9 @@ async function makeRequest(
       break
     case DOMAINS.SUPPER:
       DOMAIN_URL_REQ = DOMAIN_URL.SUPPER
+      break
+    case DOMAINS.GYM:
+      DOMAIN_URL_REQ = DOMAIN_URL.GYM
       break
   }
   return fetch(DOMAIN_URL_REQ + url, {

--- a/frontend/src/store/endpoints.ts
+++ b/frontend/src/store/endpoints.ts
@@ -119,7 +119,7 @@ export enum ENDPOINTS {
 }
 
 export enum DOMAINS {
-  FACILITY = 'facility',
+  FACILITY = 'facilities',
   EVENT = 'event',
   LAUNDRY = 'laundry',
   SOCIAL = 'social',
@@ -132,34 +132,24 @@ function proxy(url: string) {
   return 'https://cors-anywhere-rhapp.herokuapp.com/https:' + url
 }
 
-const DOMAIN_RAW_URL = {
-  FACILITY: '//rhapp-backend.rhdevs.repl.co/facilities',
-  EVENT: '//rhapp-backend.rhdevs.repl.co/scheduling',
-  LAUNDRY: '//rhapp-backend.rhdevs.repl.co/laundry',
-  SOCIAL: '//rhapp-backend.rhdevs.repl.co/social',
-  AUTH: '//rhapp-backend.rhdevs.repl.co/auth',
-  SUPPER: '//rhapp-backend.rhdevs.repl.co/supper',
-  GYM: '//rhapp-backend.rhdevs.repl.co/gym',
+function prod(domain: DOMAINS) {
+  const url = '//rhapp-backend.rhdevs.repl.co/'
+  return url + domain
 }
 
-const DOMAIN_DEV_RAW_URL = {
-  FACILITY: '//rhapp-backend-devel.rhdevs.repl.co/facilities',
-  EVENT: '//rhapp-backend-devel.rhdevs.repl.co/scheduling',
-  LAUNDRY: '//rhapp-backend-devel.rhdevs.repl.co/laundry',
-  SOCIAL: '//rhapp-backend-devel.rhdevs.repl.co/social',
-  AUTH: '//rhapp-backend-devel.rhdevs.repl.co/auth',
-  SUPPER: '//rhapp-backend-devel.rhdevs.repl.co/supper',
-  GYM: '//rhapp-backend-devel.rhdevs.repl.co/gym',
+function dev(domain: DOMAINS) {
+  const url = '//rhapp-backend-devel.rhdevs.repl.co/'
+  return proxy(url + domain)
 }
 
 export const DOMAIN_URL = {
-  FACILITY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.FACILITY : proxy(DOMAIN_DEV_RAW_URL.FACILITY),
-  EVENT: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.EVENT : proxy(DOMAIN_DEV_RAW_URL.EVENT),
-  LAUNDRY: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.LAUNDRY : proxy(DOMAIN_DEV_RAW_URL.LAUNDRY),
-  SOCIAL: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SOCIAL : proxy(DOMAIN_DEV_RAW_URL.SOCIAL),
-  AUTH: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.AUTH : proxy(DOMAIN_DEV_RAW_URL.AUTH),
-  SUPPER: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_DEV_RAW_URL.SUPPER),
-  GYM: process.env.REACT_APP_MODE === 'production' ? DOMAIN_RAW_URL.SUPPER : proxy(DOMAIN_DEV_RAW_URL.GYM),
+  FACILITY: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.FACILITY) : dev(DOMAINS.FACILITY),
+  EVENT: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.EVENT) : dev(DOMAINS.EVENT),
+  LAUNDRY: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.LAUNDRY) : dev(DOMAINS.LAUNDRY),
+  SOCIAL: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.SOCIAL) : dev(DOMAINS.SOCIAL),
+  AUTH: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.AUTH) : dev(DOMAINS.AUTH),
+  SUPPER: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.SUPPER) : dev(DOMAINS.SUPPER),
+  GYM: process.env.REACT_APP_MODE === 'production' ? prod(DOMAINS.GYM) : dev(DOMAINS.GYM),
 }
 
 async function makeRequest(

--- a/frontend/src/store/profile/action.ts
+++ b/frontend/src/store/profile/action.ts
@@ -26,12 +26,9 @@ import { ActionTypes, PROFILE_ACTIONS, User, UserCCA } from './types'
 export const fetchUserDetails = (userID: string | null) => (dispatch: Dispatch<ActionTypes>) => {
   if (userID !== null) {
     dispatch(setIsLoading(true))
-    fetch(DOMAIN_URL.SOCIAL + ENDPOINTS.USER_PROFILE + userID, {
-      method: 'GET',
-    })
-      .then((resp) => resp.json())
+    get(ENDPOINTS.USER_PROFILE, DOMAINS.SOCIAL, '/' + userID)
       .then((data) => {
-        dispatch({ type: PROFILE_ACTIONS.SET_USER_DETAILS, user: data.data[0] })
+        dispatch({ type: PROFILE_ACTIONS.SET_USER_DETAILS, user: JSON.parse(data.data)[0] })
       })
       .catch((err) => console.log(err))
   }
@@ -83,9 +80,11 @@ export const fetchUserFriends = (userID: string | null) => async (dispatch: Disp
 export const fetchUserPosts = (userID: string | null) => async (dispatch: Dispatch<ActionTypes>) => {
   if (userID !== null) {
     dispatch(setIsLoading(true))
-    await get(ENDPOINTS.ALL_POSTS, DOMAINS.SOCIAL, '/' + userID).then((data) => {
-      dispatch({ type: PROFILE_ACTIONS.SET_USER_POSTS, posts: JSON.parse(data.data) })
-    })
+    await get(ENDPOINTS.ALL_POSTS, DOMAINS.SOCIAL, '/' + userID)
+      .then((data) => {
+        dispatch({ type: PROFILE_ACTIONS.SET_USER_POSTS, posts: JSON.parse(data.data) })
+      })
+      .catch((err) => console.log(err))
   }
   dispatch(setIsLoading(false))
 }

--- a/frontend/src/store/profile/action.ts
+++ b/frontend/src/store/profile/action.ts
@@ -1,4 +1,4 @@
-import { DOMAIN_URL, ENDPOINTS } from '../endpoints'
+import { DOMAIN_URL, DOMAINS, ENDPOINTS, get } from '../endpoints'
 import { Dispatch, GetState } from '../types'
 import { ActionTypes, PROFILE_ACTIONS, User, UserCCA } from './types'
 
@@ -83,14 +83,9 @@ export const fetchUserFriends = (userID: string | null) => async (dispatch: Disp
 export const fetchUserPosts = (userID: string | null) => async (dispatch: Dispatch<ActionTypes>) => {
   if (userID !== null) {
     dispatch(setIsLoading(true))
-    await fetch(DOMAIN_URL.SOCIAL + ENDPOINTS.SPECIFIC_POST + '/' + userID, {
-      method: 'GET',
+    await get(ENDPOINTS.ALL_POSTS, DOMAINS.SOCIAL, '/' + userID).then((data) => {
+      dispatch({ type: PROFILE_ACTIONS.SET_USER_POSTS, posts: JSON.parse(data.data) })
     })
-      .then((resp) => resp.json())
-      .then((data) => {
-        dispatch({ type: PROFILE_ACTIONS.SET_USER_POSTS, posts: data.data })
-      })
-      .catch((err) => console.log(err))
   }
   dispatch(setIsLoading(false))
 }

--- a/frontend/src/store/social/action.ts
+++ b/frontend/src/store/social/action.ts
@@ -225,9 +225,10 @@ export const GetPosts = (postFilter: POSTS_FILTER, limit?: number, userId?: stri
   // const subroute: string = postFilter != POSTS_FILTER.OFFICIAL ? `?N=${limit}&userID=${userId}` : `?N=${limit}`
   const subroute = userId && limit ? `?N=${limit}&userID=${userId}` : limit ? `?N=${limit}` : ``
 
-  get(endpoint, DOMAINS.SOCIAL, subroute).then((response) => {
-    if (response.data.length > 0) {
-      const transformedPost = cloneDeep(response.data).map((post) => {
+  get(endpoint, DOMAINS.SOCIAL, subroute).then((data) => {
+    const response = JSON.parse(data.data)
+    if (response.length > 0) {
+      const transformedPost = cloneDeep(response).map((post) => {
         post.date = post.createdAt
         post.postId = post.postID
         post.ccaId = post.ccaID

--- a/frontend/src/store/social/action.ts
+++ b/frontend/src/store/social/action.ts
@@ -225,10 +225,9 @@ export const GetPosts = (postFilter: POSTS_FILTER, limit?: number, userId?: stri
   // const subroute: string = postFilter != POSTS_FILTER.OFFICIAL ? `?N=${limit}&userID=${userId}` : `?N=${limit}`
   const subroute = userId && limit ? `?N=${limit}&userID=${userId}` : limit ? `?N=${limit}` : ``
 
-  get(endpoint, DOMAINS.SOCIAL, subroute).then((data) => {
-    const response = JSON.parse(data.data)
-    if (response.length > 0) {
-      const transformedPost = cloneDeep(response).map((post) => {
+  get(endpoint, DOMAINS.SOCIAL, subroute).then((response) => {
+    if (response.data.length > 0) {
+      const transformedPost = cloneDeep(response.data).map((post) => {
         post.date = post.createdAt
         post.postId = post.postID
         post.ccaId = post.ccaID


### PR DESCRIPTION
# ‼Since this affects all our endpoints, rigorous testing of all the endpoints is required.‼

Have a feeling this will be a recurring issue in years to come, so this PR serves as a way to document this issue so that it will not be too troublesome to fix in the future. 

TLDR:
- Still have no idea what caused the issue
- My best guest is changes in recent versions of Chromium/Repl.it/Heroku caused these issues
- We are using a proxy now
- Since all the endpoints are affected, I haven't had the chance to test all the endpoints rigorously yet.

# CORS Error
Sometime around late March/early April, our middleware started experiencing CORS error and wouldn't work. We haven't pushed any changes to middleware since February so this was unusual. I tried a few hotfixes, but nothing work.

Some observations:
- Middleware was online throughout, but was not receiving the requests
- There were no issues from other people using express/heroku from recent times that I could find, so it's not a recurring issue
- Since we did not push or change any code, the issue should either stem from either 1) updates on the Heroku side or 2) recent changes to CORS on the browser side. I  was not able to confirm or fix the issue.

Since the middleware's main purpose was to circumvent CORS error, the middleware returning CORS error defeats the purpose of having a middleware. Therefor a decision was made to deprecate the middleware for something else.

# Removing the middleware
Removing the middleware and directing requests directly to our replit backend had some success. All the requests that did not require preflights worked fine, however, those that required preflights returned a redirect error. If we look at our backend and the Networking Tools on the Chrome Debugger, whenever we make a call to one of our registered blueprints, two things happens, an internal redirect, before the actual call. The problem arises when we try to pass additional headers to the endpoints. I'm not too familiar with what is going on, but essentially what I could find was that if we pass additional headers, we expect a 2xx response and not a 3xx response, but because we are doing an internal redirect, we return a 3xx response initially followed by a 2xx. 

Another weird behaviour I have no explanation for is that our `axios` calls return CORS but all our `fetch` requests return perfectly fine. I've checked the defaults and everything seems fine. I think this the explanation for the issue, but we have CORS enabled in our backend, so it shouldn't be happening. https://stackoverflow.com/questions/64793572/axios-fails-cors-but-fetch-works-fine

A summary of weird behaviour I cannot explain or fix:
- If we have additional headers on our requests, it will fail because we 'cannot pass headers to a redirect'
- If we use  `axios` we return CORS error even though we have CORS enabled on the backend repl.it

# Using Cors Anywhere as a proxy
The alternative solution I had in mind was to use CORS Anywhere as a proxy for us to bypass any CORS errors. It's very easily abused and very unsafe, but at this point, as long as it works it should be fine, plus we are using it only in our development environment, it should be fine. Another extremely weird behaviour occurs here as well. When I initially hosted the proxy on our repl.it, it was returning CORS error from the browser to the Repl. I have completely no clue why, but I suspect this is the same reason why our backend Repl returns CORS errors even though it's properly setup to handle CORS. Migrating the proxy over the Heroku solved the issue. Our new 'middleware' or proxy is hosted at https://cors-anywhere-rhapp.herokuapp.com. However, a lot of our code requires some minor changes, such as parsing the response into usable data, and I haven't fixed all of them yet.

The PR are changes in the frontend, with these main changes:
- Switched to `axios`
- Removed any calls to the middleware, switch to using a proxy instead