### PR TITLE
fixed 24hr booking bug

### DIFF
--- a/frontend/src/store/facilityBooking/action.ts
+++ b/frontend/src/store/facilityBooking/action.ts
@@ -58,7 +58,7 @@ export const updateBookingDailyView = (date: Date, selectedFacilityId: number) =
 
         if (startDate === date.getDate() && startTimeObject.getMonth() === date.getMonth()) {
           const startHour = startTimeObject.getHours()
-          const endHour = endTimeObject.getHours() < startHour ? 24 : endTimeObject.getHours()
+          const endHour = endTimeObject.getHours() <= startHour ? 24 : endTimeObject.getHours()
           let timestamp = booking.startTime
           for (let hour = startHour; hour < endHour; hour++) {
             updatedTimeBlocks[hour] = {


### PR DESCRIPTION
Resolves: Booking Bug where 24-hour bookings in the same day are not shown in RH-App

Changed const endHour = endTimeObject.getHours() < startHour to const endHour = endTimeObject.getHours() <= startHour so that for 00:00 to 00:00, end hour is at 24 instead of 0.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in** the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
