### PR TITLE
Debug 24hr bug

### DIFF
--- a/frontend/src/store/facilityBooking/action.ts
+++ b/frontend/src/store/facilityBooking/action.ts
@@ -75,7 +75,7 @@ export const updateBookingDailyView = (date: Date, selectedFacilityId: number) =
 
         if (startDate < date.getDate() && startTimeObject.getMonth() <= date.getMonth()) {
           const startHour = 0
-          const endHour = endTimeObject.getHours()
+          const endHour = endTimeObject.getHours() == 0 ? 24 : endTimeObject.getHours()
           let timestamp = booking.startTime
           for (let hour = startHour; hour < endHour; hour++) {
             updatedTimeBlocks[hour] = {


### PR DESCRIPTION
Resolves: 24-hour booking bug

changed const endHour = endTimeObject.getHours() to const endHour = endTimeObject.getHours() == 0 ? 24 : endTimeObject.getHours() so that for endtime with hour 0, all blocks will be marked occupied

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in** the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
